### PR TITLE
Added configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,14 @@ Usage
 var iM880 = require('iM880');
 
 // call the constructor with a deviceID and deviceGroup
+SERIAL_PORT  = '/dev/ttyUSB1'; // serial port to connect to
 DEVICE_ID    = 0x04; // in range [0x0000, 0xFFFF)
 DEVICE_GROUP = 0x10; // in range [0x00, 0xFF)
-SERIAL_PORT  = '/dev/ttyUSB1'; // optional argument, defaults to /dev/ttyUSB0
-SF = 10;  // optional argument, defaults to 10
-TX_PWR = 20; // optional argument, defaults to 20
-device = new iM880(DEVICE_ID, DEVICE_GROUP, SERIAL_PORT, SF, TX_PWR);
+SF = 10;  // spreading factor, optional argument, defaults to 10
+BANDWIDTH = 125000; // bandwidth, optional argument, defaults to 125000
+ERROR_CODING = 4/5; // error coding, optional argument, defaults to 4/5
+TX_PWR = 20; // transmit power in dBm, optional argument, defaults to 20
+device = new iM880(DEVICE_ID, DEVICE_GROUP, SERIAL_PORT, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
 
 // callback for when constructor done and device configured
 device.on('config-done', function(statusmsg) {

--- a/example/configure-example.js
+++ b/example/configure-example.js
@@ -1,4 +1,4 @@
-#!/usr/bin / env node
+#!/usr/bin/env node
 
 var iM880 = require('../iM880');
 
@@ -8,11 +8,11 @@ DEVICE_GROUP = 0x10;
 SERIAL_PORT = '/dev/ttyUSB1';
 SF = 10;
 TX_PWR = 10;
-BANDWIDTH = 0;
-ERROR_CODING = 1;
+BANDWIDTH = 125000;
+ERROR_CODING = 4/5;
 
 // call the construction with and endpointID
-device = new iM880(DEVICE_ID, DEVICE_GROUP, SERIAL_PORT, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
+device = new iM880(SERIAL_PORT, DEVICE_ID, DEVICE_GROUP, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
 // wait for config-done message and print endpointID
 var msg = new Uint8Array([ 9, 8, 10, 67 ]);
 device.on('config-done', function(statusmsg) {
@@ -31,5 +31,8 @@ device.on('rx-msg', function(data) {
 
 setTimeout(function() {
     console.log("Changing settings");
-    device.configure(DEVICE_ID, DEVICE_GROUP, 7,2,1,TX_PWR);
+    new_spreading_factor = 7;
+    new_bandwidth = 250000;
+    new_error_coding = 4/5;
+    device.configure(DEVICE_ID, DEVICE_GROUP, new_spreading_factor, new_bandwidth, new_error_coding, TX_PWR);
 }, 20*1000);

--- a/example/configure-example.js
+++ b/example/configure-example.js
@@ -28,3 +28,8 @@ device.on('rx-msg', function(data) {
   console.log('Received message!!');
   console.log(data);
 });
+
+setTimeout(function() {
+    console.log("Changing settings");
+    device.configure(DEVICE_ID, DEVICE_GROUP, 7,2,1,TX_PWR);
+}, 20*1000);

--- a/example/rx-example.js
+++ b/example/rx-example.js
@@ -1,18 +1,18 @@
-#!/usr/bin / env node
+#!/usr/bin/env node
 
 var iM880 = require('../iM880');
 
 // set the endpoint ID
+SERIAL_PORT = '/dev/ttyUSB1';
 DEVICE_ID = 0x09;
 DEVICE_GROUP = 0x10;
-SERIAL_PORT = '/dev/ttyUSB1';
 SF = 10;
+BANDWIDTH = 125000;
+ERROR_CODING = 4/5;
 TX_PWR = 10;
-BANDWIDTH = 0;
-ERROR_CODING = 1;
 
 // call the construction with and endpointID
-device = new iM880(DEVICE_ID, DEVICE_GROUP, SERIAL_PORT, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
+device = new iM880(SERIAL_PORT, DEVICE_ID, DEVICE_GROUP, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
 // wait for config-done message and print endpointID
 var msg = new Uint8Array([ 9, 8, 10, 67 ]);
 device.on('config-done', function(statusmsg) {

--- a/example/tx-example.js
+++ b/example/tx-example.js
@@ -1,13 +1,18 @@
-#!/usr/bin / env node
+#!/usr/bin/env node
 
 var iM880 = require('../iM880');
 
 // set the endpoint ID
+SERIAL_PORT = '/dev/ttyUSB1';
 DEVICE_ID = 0x07;
-DEVICE_GROUP = 0x11;
+DEVICE_GROUP = 0x10;
+SF = 10;
+BANDWIDTH = 125000;
+ERROR_CODING = 4/5;
+TX_PWR = 10;
 
 // call the construction with and endpointID
-device = new iM880(DEVICE_ID, DEVICE_GROUP );
+device = new iM880(SERIAL_PORT, DEVICE_ID, DEVICE_GROUP, SF, BANDWIDTH, ERROR_CODING, TX_PWR);
 // wait for config-done message and print endpointID
 var msg = new Uint8Array([ 9, 8, 10, 67, 89, 100, 43 ]);
 device.on('config-done', function(statusmsg) {

--- a/iM880.js
+++ b/iM880.js
@@ -69,23 +69,38 @@ var SerialPort = require('serialport');
 var events = require('events');
 var util = require('util');
 
-var iM880 = function(deviceID, deviceGroup, serport, sf, bandwidth, error_coding, tx_pwr) {
+var iM880 = function(serport, deviceID, deviceGroup, sf, bandwidth, error_coding, tx_pwr) {
 
-
-  if (serport == null) {
-    serport = '/dev/ttyUSB0';
-  }
+  // default parameters
   if (sf == null) {
     sf = 10;
   }
   if(tx_pwr == null) {
     tx_pwr = 20;
   }
-  if(bandwidth == null){
-      bandwidth = 0;
+
+  // convert bandwidth to number configuration wants
+  bandwidth_num = 0;
+  if(bandwidth == 500000) {
+    bandwidth_num = 2;
+  } else if (bandwidth == 250000) {
+    bandwidth_num = 1;
+  } else {
+    // 125000 bandwidth
+    bandwidth_num = 0;
   }
-  if(error_coding = null){
-      error_coding = 1;
+
+  // convert error coding to number configuration wants
+  error_coding_num = 0;
+  if (error_coding == 4/8){
+    error_coding_num = 4;
+  } else if (error_coding == 4/7) {
+    error_coding_num = 3;
+  } else if (error_coding == 4/6) {
+    error_coding_num = 2;
+  } else {
+    // 4/5 error coding
+    error_coding_num = 0;
   }
 
   this.port = new SerialPort(
@@ -176,7 +191,7 @@ var iM880 = function(deviceID, deviceGroup, serport, sf, bandwidth, error_coding
           // console.log('iM880B pinged!');
           var config_msg = new Uint8Array([
             0x01, 0x0, deviceGroup, 0x10, (deviceID & 0xFF00), 
-            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth, sf, error_coding,
+            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth_num, sf, error_coding_num,
             tx_pwr, 0, 0x01, 0x03, 0xE8, 0x0F, 0x0F, 0, 0, 0, 0 ]);
           var packet = that.makePacket(
               DEVMGMT_ID, DEVMGMT_MSG_SET_RADIO_CONFIG_REQ, config_msg);
@@ -267,27 +282,46 @@ iM880.prototype.sendConfirmed = function(destDevice, destGroup, msg) {
 
 iM880.prototype.configure = function(deviceID, deviceGroup, sf, bandwidth, error_coding, tx_pwr) {
 
-    if (sf == null) {
-        sf = 10;
-    }
-    if(tx_pwr == null) {
-        tx_pwr = 20;
-    }
-    if(bandwidth == null){
-        bandwidth = 0;
-    }
-    if(error_coding = null){
-        error_coding = 1;
-    }
+  // default parameters
+  if (sf == null) {
+    sf = 10;
+  }
+  if (tx_pwr == null) {
+    tx_pwr = 20;
+  }
 
-    var config_msg = new Uint8Array([
-            0x01, 0x0, deviceGroup, 0x10, (deviceID & 0xFF00), 
-            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth, sf, error_coding,
-            tx_pwr, 0, 0x01, 0x03, 0xE8, 0x0F, 0x0F, 0, 0, 0, 0 ]);
-    var packet = this.makePacket(
-              DEVMGMT_ID, DEVMGMT_MSG_SET_RADIO_CONFIG_REQ, config_msg);
-    this.currState = WAIT_CONFIG_ACK;
-    this.port.write(packet);
+  // convert bandwidth to number configuration wants
+  bandwidth_num = 0;
+  if (bandwidth == 500000) {
+    bandwidth_num = 2;
+  } else if (bandwidth = 250000) {
+    bandwidth_num = 1;
+  } else {
+    // 125000 bandwidth
+    bandwidth_num = 0;
+  }
+
+  // convert error coding to number configuration wants
+  error_coding_num = 0;
+  if (error_coding == 4/8){
+    error_coding_num = 4;
+  } else if (error_coding == 4/7) {
+    error_coding_num = 3;
+  } else if (error_coding == 4/6) {
+    error_coding_num = 2;
+  } else {
+    // 4/5 error coding
+    error_coding_num = 0;
+  }
+
+  var config_msg = new Uint8Array([
+      0x01, 0x0, deviceGroup, 0x10, (deviceID & 0xFF00),
+      (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth_num, sf, error_coding_num,
+      tx_pwr, 0, 0x01, 0x03, 0xE8, 0x0F, 0x0F, 0, 0, 0, 0 ]);
+  var packet = this.makePacket(
+      DEVMGMT_ID, DEVMGMT_MSG_SET_RADIO_CONFIG_REQ, config_msg);
+  this.currState = WAIT_CONFIG_ACK;
+  this.port.write(packet);
 }
 
 iM880.prototype.sendBroadcast = function(msg) {

--- a/iM880.js
+++ b/iM880.js
@@ -69,7 +69,9 @@ var SerialPort = require('serialport');
 var events = require('events');
 var util = require('util');
 
-var iM880 = function(deviceID, deviceGroup, serport, sf, tx_pwr) {
+var iM880 = function(deviceID, deviceGroup, serport, sf, bandwidth, error_coding, tx_pwr) {
+
+
   if (serport == null) {
     serport = '/dev/ttyUSB0';
   }
@@ -79,11 +81,18 @@ var iM880 = function(deviceID, deviceGroup, serport, sf, tx_pwr) {
   if(tx_pwr == null) {
     tx_pwr = 20;
   }
+  if(bandwidth == null){
+      bandwidth = 0;
+  }
+  if(error_coding = null){
+      error_coding = 1;
+  }
 
   this.port = new SerialPort(
       serport, {baudrate : 115200, parser : SerialPort.parsers.raw});
   this.decoder = new slip.Decoder({});
   this.currState = INIT;
+  
   var that = this;
   this.port.on('open', function() {
     // make ping packet
@@ -167,7 +176,7 @@ var iM880 = function(deviceID, deviceGroup, serport, sf, tx_pwr) {
           // console.log('iM880B pinged!');
           var config_msg = new Uint8Array([
             0x01, 0x0, deviceGroup, 0x10, (deviceID & 0xFF00), 
-            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, 0, sf, 0x01,
+            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth, sf, error_coding,
             tx_pwr, 0, 0x01, 0x03, 0xE8, 0x0F, 0x0F, 0, 0, 0, 0 ]);
           var packet = that.makePacket(
               DEVMGMT_ID, DEVMGMT_MSG_SET_RADIO_CONFIG_REQ, config_msg);
@@ -255,6 +264,31 @@ iM880.prototype.sendConfirmed = function(destDevice, destGroup, msg) {
   this.port.write(packet);
   this.currState = WAIT_CMD;
 };
+
+iM880.prototype.configure = function(deviceID, deviceGroup, sf, bandwidth, error_coding, tx_pwr) {
+
+    if (sf == null) {
+        sf = 10;
+    }
+    if(tx_pwr == null) {
+        tx_pwr = 20;
+    }
+    if(bandwidth == null){
+        bandwidth = 0;
+    }
+    if(error_coding = null){
+        error_coding = 1;
+    }
+
+    var config_msg = new Uint8Array([
+            0x01, 0x0, deviceGroup, 0x10, (deviceID & 0xFF00), 
+            (deviceID & 0xFF), 0, 0x03, 0, 0xD5, 0xC8, 0xE4, bandwidth, sf, error_coding,
+            tx_pwr, 0, 0x01, 0x03, 0xE8, 0x0F, 0x0F, 0, 0, 0, 0 ]);
+    var packet = this.makePacket(
+              DEVMGMT_ID, DEVMGMT_MSG_SET_RADIO_CONFIG_REQ, config_msg);
+    this.currState = WAIT_CONFIG_ACK;
+    this.port.write(packet);
+}
 
 iM880.prototype.sendBroadcast = function(msg) {
   // make the packet and add destination addresses to msg

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "iM880-serial-comm",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "serial communication with iM880",
   "main": "iM880.js",
   "repository": {


### PR DESCRIPTION
Can now configure Bandwidth and Error Coding, both at init and later

Major changes:
 * Moved serial port to be first argument and made it non-optional
 * bandwidth can be provided [125000 (default), 250000, or 500000]
 * error coding can be provided [4/5 (default), 4/6, 4/7, or 4/8]
 * updated to version 4.0.0